### PR TITLE
Implement deleting empty cells

### DIFF
--- a/src/components/cell.ts
+++ b/src/components/cell.ts
@@ -69,6 +69,7 @@ export class CellElement extends LitElement {
   firstUpdated(changedProperties: any) {
     super.firstUpdated(changedProperties);
     this.addEventListener("keydown", (event) => {
+      // When the event comes back up the tree and hasn't been cancelled
       if (event.key === "Enter") {
         if (event.ctrlKey) {
           this.runtime.controls.emit({ id: this.cell.id, type: "RUN_CELL" });
@@ -86,6 +87,11 @@ export class CellElement extends LitElement {
             insertNewCell: true,
           });
         }
+      } else if (event.key === "Backspace" && (this.cell.textContent == null || this.cell.textContent == "")) {
+        this.runtime.controls.emit({
+          id: this.cell.id,
+          type: "REMOVE_CELL",
+        });
       }
     });
 

--- a/src/components/cell.ts
+++ b/src/components/cell.ts
@@ -87,13 +87,27 @@ export class CellElement extends LitElement {
             insertNewCell: true,
           });
         }
-      } else if (event.key === "Backspace" && (this.cell.textContent == null || this.cell.textContent == "")) {
+        // After the event comes up (hasn't been cancelled) and it's a deletion-event
+        // @ts-ignore
+      } else if (event.key === "Backspace" && event._maybeDeleteCell) {
         this.runtime.controls.emit({
           id: this.cell.id,
           type: "REMOVE_CELL",
         });
       }
     });
+
+    this.addEventListener(
+      "keydown",
+      (event) => {
+        // Before anything happens, note down if this could be a deletion-event
+        if (event.key === "Backspace" && (this.cell.textContent == null || this.cell.textContent == "")) {
+          // @ts-ignore
+          event._maybeDeleteCell = true;
+        }
+      },
+      true
+    );
 
     [].slice.call(document.querySelectorAll(".dropdown-toggle")).map((e) => new Dropdown(e));
 

--- a/src/components/cell.ts
+++ b/src/components/cell.ts
@@ -101,7 +101,7 @@ export class CellElement extends LitElement {
       "keydown",
       (event) => {
         // Before anything happens, note down if this could be a deletion-event
-        if (event.key === "Backspace" && (this.cell.textContent == null || this.cell.textContent == "")) {
+        if (event.key === "Backspace" && (this.cell.textContent === null || this.cell.textContent === "")) {
           // @ts-ignore
           event._maybeDeleteCell = true;
         }

--- a/src/components/editor/codeMirror.ts
+++ b/src/components/editor/codeMirror.ts
@@ -152,6 +152,8 @@ const commonExtensions = [
 
   keymap.of([
     { key: "Shift-Enter", run: () => true },
+    { key: "Alt-Enter", run: () => true },
+    { key: "Ctrl-Enter", run: () => true },
     ...defaultKeymap,
     ...commentKeymap,
     ...completionKeymap,
@@ -212,24 +214,6 @@ export function createCodeMirrorEditor(
             });
             return true;
           }
-        }
-        return false;
-      },
-    },
-    {
-      key: "Backspace",
-      run: (target) => {
-        const selections = target.state.selection.ranges;
-        if (
-          target.state.doc.lines === 1 &&
-          selections.length === 1 &&
-          selections[0].head <= 0 &&
-          cell.textContent == ""
-        ) {
-          _runtime.controls.emit({
-            id: cell.id,
-            type: "REMOVE_CELL",
-          });
         }
         return false;
       },

--- a/src/components/editor/codeMirror.ts
+++ b/src/components/editor/codeMirror.ts
@@ -216,6 +216,24 @@ export function createCodeMirrorEditor(
         return false;
       },
     },
+    {
+      key: "Backspace",
+      run: (target) => {
+        const selections = target.state.selection.ranges;
+        if (
+          target.state.doc.lines === 1 &&
+          selections.length === 1 &&
+          selections[0].head <= 0 &&
+          cell.textContent == ""
+        ) {
+          _runtime.controls.emit({
+            id: cell.id,
+            type: "REMOVE_CELL",
+          });
+        }
+        return false;
+      },
+    },
   ]);
 
   const editorView = new EditorView({

--- a/src/components/editor/contentEditor.ts
+++ b/src/components/editor/contentEditor.ts
@@ -43,22 +43,22 @@ export class StarboardContentEditor extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener("keydown", (event: KeyboardEvent) => {
-      if (event.key === "Enter" && this.view && this.view.hasFocus()) {
-        if (event.ctrlKey) {
-          event.stopPropagation();
-          return true;
-        } else if (event.shiftKey) {
-          event.stopPropagation();
-          return true;
+    this.addEventListener(
+      "keydown",
+      (event: KeyboardEvent) => {
+        // Stop the text editor from inserting a new line
+        if (event.key === "Enter" && this.view && this.view.hasFocus()) {
+          if (event.ctrlKey) {
+            event.stopPropagation();
+            return true;
+          } else if (event.shiftKey) {
+            event.stopPropagation();
+            return true;
+          }
         }
-      } else if (event.key === "Backspace" && this.view && this.view.hasFocus() && this.content.textContent == "") {
-        /*this.runtime.controls.emit({
-          id: this.content.id,
-          type: "REMOVE_CELL",
-        });*/
-      }
-    });
+      },
+      true
+    );
 
     prosemirrorPromise.then((_pm) => {
       if (this.view) {

--- a/src/components/editor/contentEditor.ts
+++ b/src/components/editor/contentEditor.ts
@@ -52,6 +52,11 @@ export class StarboardContentEditor extends LitElement {
           event.stopPropagation();
           return true;
         }
+      } else if (event.key === "Backspace" && this.view && this.view.hasFocus() && this.content.textContent == "") {
+        /*this.runtime.controls.emit({
+          id: this.content.id,
+          type: "REMOVE_CELL",
+        });*/
       }
     });
 

--- a/src/components/editor/monaco.ts
+++ b/src/components/editor/monaco.ts
@@ -165,6 +165,26 @@ export function createMonacoEditor(
     wordWrap: opts.wordWrap,
   });
 
+  function preventStopPropagation(ev: KeyboardEvent) {
+    // @ts-ignore
+    ev._stopImmediatePropagation = ev.stopImmediatePropagation;
+    ev.stopImmediatePropagation = () => {};
+    // @ts-ignore
+    ev._stopPropagation = ev.stopPropagation;
+    ev.stopPropagation = () => {};
+  }
+  function restoreStopPropagation(ev: KeyboardEvent) {
+    // @ts-ignore
+    ev.stopImmediatePropagation = ev._stopImmediatePropagation;
+    // @ts-ignore
+    ev.stopPropagation = ev._stopPropagation;
+  }
+  element.addEventListener("keydown", preventStopPropagation, true);
+  element.addEventListener("keydown", restoreStopPropagation);
+  editor.onDidDispose(() => {
+    element.removeEventListener("keydown", preventStopPropagation, true);
+    element.removeEventListener("keydown", restoreStopPropagation);
+  });
   const setEditable = function (editor: monaco.editor.IStandaloneCodeEditor, _isLocked: boolean | undefined): void {
     editor.updateOptions({ readOnly: !!_isLocked });
   };

--- a/src/components/editor/monaco.ts
+++ b/src/components/editor/monaco.ts
@@ -79,7 +79,8 @@ function makeEditorResizeToFitContent(editor: monaco.editor.IStandaloneCodeEdito
 function addEditorKeyboardShortcuts(
   editor: monaco.editor.IStandaloneCodeEditor,
   emit: (event: CellEvent) => void,
-  cellId: string
+  cellId: string,
+  isCellEmpty: () => boolean
 ) {
   editor.addAction({
     id: "run-cell",
@@ -126,6 +127,14 @@ function addEditorKeyboardShortcuts(
           id: cellId,
           type: "FOCUS_CELL",
           focus: "previous",
+        });
+      }
+    } else if (e.keyCode === monaco.KeyCode.Backspace) {
+      // Check if we're at the beginning, only then check the actual contents
+      if (editor.getModel()?.getLineCount() === 1 && editor.getPosition()?.column === 1 && isCellEmpty()) {
+        emit({
+          id: cellId,
+          type: "REMOVE_CELL",
         });
       }
     }
@@ -197,7 +206,7 @@ export function createMonacoEditor(
   window.addEventListener("resize", resizeDebounced);
 
   makeEditorResizeToFitContent(editor);
-  addEditorKeyboardShortcuts(editor, runtime.controls.emit, cell.id);
+  addEditorKeyboardShortcuts(editor, runtime.controls.emit, cell.id, () => cell.textContent == "");
 
   const model = editor.getModel();
   if (model) {

--- a/src/components/editor/monaco.ts
+++ b/src/components/editor/monaco.ts
@@ -165,6 +165,10 @@ export function createMonacoEditor(
     wordWrap: opts.wordWrap,
   });
 
+  // Monaco swallows all keyboard shortcuts (calls .stopPropagation on them)
+  // This means that usually, no shortcuts would bubble up from monaco to starboard (breaking all shortcuts)
+  // Therefore, we replace .stopPropagation with a dummy event in the capturing phase
+  // And restore .stopPropagation in the bubbling phase
   function preventStopPropagation(ev: KeyboardEvent) {
     // @ts-ignore
     ev._stopImmediatePropagation = ev.stopImmediatePropagation;

--- a/src/components/editor/monaco.ts
+++ b/src/components/editor/monaco.ts
@@ -79,8 +79,7 @@ function makeEditorResizeToFitContent(editor: monaco.editor.IStandaloneCodeEdito
 function addEditorKeyboardShortcuts(
   editor: monaco.editor.IStandaloneCodeEditor,
   emit: (event: CellEvent) => void,
-  cellId: string,
-  isCellEmpty: () => boolean
+  cellId: string
 ) {
   editor.addAction({
     id: "run-cell",
@@ -89,11 +88,7 @@ function addEditorKeyboardShortcuts(
 
     contextMenuGroupId: "starboard",
     contextMenuOrder: 0,
-    run: (_ed) =>
-      emit({
-        id: cellId,
-        type: "RUN_CELL",
-      }),
+    run: (_ed) => {},
   });
 
   editor.addAction({
@@ -103,12 +98,7 @@ function addEditorKeyboardShortcuts(
 
     contextMenuGroupId: "starboard",
     contextMenuOrder: 1,
-    run: (_ed) =>
-      emit({
-        id: cellId,
-        type: "RUN_CELL",
-        focus: "next",
-      }),
+    run: (_ed) => {},
   });
 
   editor.onKeyDown((e) => {
@@ -129,14 +119,6 @@ function addEditorKeyboardShortcuts(
           focus: "previous",
         });
       }
-    } else if (e.keyCode === monaco.KeyCode.Backspace) {
-      // Check if we're at the beginning, only then check the actual contents
-      if (editor.getModel()?.getLineCount() === 1 && editor.getPosition()?.column === 1 && isCellEmpty()) {
-        emit({
-          id: cellId,
-          type: "REMOVE_CELL",
-        });
-      }
     }
   });
 
@@ -147,13 +129,7 @@ function addEditorKeyboardShortcuts(
 
     contextMenuGroupId: "starboard",
     contextMenuOrder: 2,
-    run: (_ed) =>
-      emit({
-        id: cellId,
-        type: "RUN_CELL",
-        focus: "next",
-        insertNewCell: true,
-      }),
+    run: (_ed) => {},
   });
 }
 
@@ -206,7 +182,7 @@ export function createMonacoEditor(
   window.addEventListener("resize", resizeDebounced);
 
   makeEditorResizeToFitContent(editor);
-  addEditorKeyboardShortcuts(editor, runtime.controls.emit, cell.id, () => cell.textContent == "");
+  addEditorKeyboardShortcuts(editor, runtime.controls.emit, cell.id);
 
   const model = editor.getModel();
   if (model) {


### PR DESCRIPTION
Empty cells where the cursor is at the beginning of the cell can now be deleted using backspace. And the event handling has been improved a bit.

By the way, where should I best document all keyboard shortcuts that editors might have to handle?

New design:
When a keyboard event happens, the editor handles it.
If it's a Starboard-shortcut, the editor has two options:
- Recognize the shortcut and do nothing (e.g. don't insert a new line when the user presses `Shift`+`Enter`)
- Recognize the shortcut, do something custom and call `event.stopPropagation()` (e.g. close a menu when the user presses `Esc`)

If you decide to merge this and run into the inevitable conflicts, please do copy over [the codemirror changes](https://github.com/gzuidhof/starboard-notebook/pull/44/files#diff-97f391946e97c9989af7b8800c3a41788280742d09125a3640e40d62d58a7904).