### PR TITLE
Support inserting cells with textContent

### DIFF
--- a/src/components/editor/codemirror/editor.ts
+++ b/src/components/editor/codemirror/editor.ts
@@ -37,6 +37,8 @@ const commonExtensions = [
 
   keymap.of([
     { key: "Shift-Enter", run: () => true },
+    { key: "Alt-Enter", run: () => true },
+    { key: "Ctrl-Enter", run: () => true },
     ...defaultKeymap,
     ...commentKeymap,
     ...completionKeymap,
@@ -73,7 +75,8 @@ export function createCodeMirrorEditor(
           const firstLine = target.state.doc.line(1);
           const cursorPosition = target.state.selection.ranges[0].head;
           if (firstLine.from <= cursorPosition && cursorPosition <= firstLine.to) {
-            return runtime.controls.focusCell({ id: cell.id, focusTarget: "previous" });
+            runtime.controls.focusCell({ id: cell.id, focusTarget: "previous" });
+            return true;
           }
         }
         return false;
@@ -86,7 +89,8 @@ export function createCodeMirrorEditor(
           const lastline = target.state.doc.line(target.state.doc.lines);
           const cursorPosition = target.state.selection.ranges[0].head;
           if (lastline.from <= cursorPosition && cursorPosition <= lastline.to) {
-            return runtime.controls.focusCell({ id: cell.id, focusTarget: "next" });
+            runtime.controls.focusCell({ id: cell.id, focusTarget: "next" });
+            return true;
           }
         }
         return false;

--- a/src/content/notebookContent.ts
+++ b/src/content/notebookContent.ts
@@ -59,7 +59,7 @@ export function addCellToNotebookContent(
   const id = data.id || generateUniqueCellId();
   const cell: Cell = {
     cellType,
-    textContent: "",
+    textContent: data.textContent ? data.textContent + "" : "",
     metadata: {
       properties: {},
       ...(data.metadata ? data.metadata : {}),

--- a/src/content/notebookContent.ts
+++ b/src/content/notebookContent.ts
@@ -59,7 +59,7 @@ export function addCellToNotebookContent(
   const id = data.id || generateUniqueCellId();
   const cell: Cell = {
     cellType,
-    textContent: data.textContent ? data.textContent + "" : "",
+    textContent: data.textContent || "",
     metadata: {
       properties: {},
       ...(data.metadata ? data.metadata : {}),

--- a/src/runtime/create.ts
+++ b/src/runtime/create.ts
@@ -205,24 +205,21 @@ export function setupRuntime(notebook: StarboardNotebookElement): Runtime {
       return false;
     },
 
-    focusCell(opts: FocusCellOptions) {
+    async focusCell(opts: FocusCellOptions) {
       const idx = requireIndexOfCellId(rt.content.cells, opts.id);
+      await rt.dom.notebook.updateComplete;
       const cellElements = rt.dom.cells;
       const cell = cellElements[idx];
 
       if (dispatchStarboardEvent(cell, "sb:focus_cell", opts)) {
         if (opts.focusTarget === "previous") {
-          window.setTimeout(() => {
-            const next = cellElements[idx - 1];
-            if (next) next.focusEditor({ position: "end" });
-          });
+          const next = cellElements[idx - 1];
+          if (next) next.focusEditor({ position: "end" });
         } else if (opts.focusTarget === "next") {
-          window.setTimeout(() => {
-            const next = cellElements[idx + 1];
-            if (next) {
-              next.focusEditor({ position: "start" });
-            }
-          });
+          const next = cellElements[idx + 1];
+          if (next) {
+            next.focusEditor({ position: "start" });
+          }
         } else if (opts.focusTarget === undefined) {
           cell.focus({});
         }

--- a/src/types/runtime/index.ts
+++ b/src/types/runtime/index.ts
@@ -56,7 +56,7 @@ export interface RuntimeControls {
   setCellProperty(opts: SetCellPropertyOptions): boolean;
   resetCell(opts: ResetCellOptions): boolean;
   runCell(opts: RunCellOptions): boolean;
-  focusCell(opts: FocusCellOptions): boolean;
+  focusCell(opts: FocusCellOptions): Promise<boolean>;
   clearCell(opts: ClearCellOptions): boolean;
   runAllCells(opts: { onlyRunOnLoad?: boolean }): Promise<void>;
   clearAllCells(opts: Record<string, any>): void;


### PR DESCRIPTION
Adds support for inserting cells with textContent. Now stuff like this works:

```js
const thisId = runtime.content.cells[0].id;
  runtime.controls.insertCell({ 
    adjacentCellId: thisId, 
    position: "after", 
    data: {
      cellType: "plaintext",
      textContent: "cat"
    }
  });
```


Oh, I should probably have created this branch from the master branch instead of from this branch ( https://github.com/gzuidhof/starboard-notebook/pull/49 )