### PR TITLE
Add optional filesystem to notebook runtime

### DIFF
--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -11,14 +11,31 @@ export type AsyncResult<T, E = Error> = Promise<
     }
 >;
 
-/**
- * All of the functions can reject with a `NotebookFilesystemError`
- */
 export interface NotebookFilesystem {
-  get(opts: { path: string }): AsyncResult<string>;
-  put(opts: { path: string; value: string }): AsyncResult<undefined>;
+  /**
+   * Get a file or directory at a given path.
+   * @returns The contents of the file. `null` corresponds to a directory
+   */
+  get(opts: { path: string }): AsyncResult<string | null>;
+
+  /**
+   * Creates or replaces a file or directory at a given path.
+   * @param opts.value The contents of the file. `null` corresponds to a directory
+   */
+  put(opts: { path: string; value: string | null }): AsyncResult<undefined>;
+
+  /**
+   * Deletes a file or directory at a given path
+   */
   delete(opts: { path: string }): AsyncResult<undefined>;
+
+  /**
+   * Move a file or directory to a new path. Can be used for renaming
+   */
   move(opts: { path: string; newPath: string }): AsyncResult<undefined>;
-  makeDirectory(opts: { path: string }): AsyncResult<undefined>;
+
+  /**
+   * List the files in a directory
+   */
   listDirectory(opts: { path: string }): AsyncResult<string[]>;
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -1,7 +1,14 @@
+export interface NotebookFilesystemError extends Error {
+  status: number;
+}
+
+/**
+ * All of the functions can reject with a `NotebookFilesystemError`
+ */
 export interface NotebookFilesystem {
-  get(absolutePath: string): Promise<string>;
-  put(absolutePath: string, value: string): Promise<void>;
-  delete(absolutePath: string): Promise<void>;
-  listFiles(absolutePath: string): Promise<string[]>;
-  move(absolutePath: string, newAbsolutePath: string): Promise<void>;
+  get(opts: { path: string }): Promise<string>;
+  put(opts: { path: string; value: string }): Promise<void>;
+  delete(opts: { path: string }): Promise<void>;
+  listFiles(opts: { path: string }): Promise<string[]>;
+  move(opts: { path: string; newPath: string }): Promise<void>;
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -1,14 +1,23 @@
-export interface NotebookFilesystemError extends Error {
-  status: number;
-}
+export type AsyncResult<T, E = Error> = Promise<
+  | {
+      ok: true;
+      data: T;
+    }
+  | {
+      ok: false;
+      status: number;
+      error: E;
+      detail?: string;
+    }
+>;
 
 /**
  * All of the functions can reject with a `NotebookFilesystemError`
  */
 export interface NotebookFilesystem {
-  get(opts: { path: string }): Promise<string>;
-  put(opts: { path: string; value: string }): Promise<void>;
-  delete(opts: { path: string }): Promise<void>;
-  listFiles(opts: { path: string }): Promise<string[]>;
-  move(opts: { path: string; newPath: string }): Promise<void>;
+  get(opts: { path: string }): AsyncResult<string>;
+  put(opts: { path: string; value: string }): AsyncResult<void>;
+  delete(opts: { path: string }): AsyncResult<void>;
+  listFiles(opts: { path: string }): AsyncResult<string[]>;
+  move(opts: { path: string; newPath: string }): AsyncResult<void>;
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -35,7 +35,7 @@ export interface NotebookFilesystem {
   move(opts: { path: string; newPath: string }): AsyncResult<undefined>;
 
   /**
-   * List the files in a directory
+   * List the files and subdirectories in a directory
    */
   listDirectory(opts: { path: string }): AsyncResult<string[]>;
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -16,8 +16,9 @@ export type AsyncResult<T, E = Error> = Promise<
  */
 export interface NotebookFilesystem {
   get(opts: { path: string }): AsyncResult<string>;
-  put(opts: { path: string; value: string }): AsyncResult<void>;
-  delete(opts: { path: string }): AsyncResult<void>;
-  listFiles(opts: { path: string }): AsyncResult<string[]>;
-  move(opts: { path: string; newPath: string }): AsyncResult<void>;
+  put(opts: { path: string; value: string }): AsyncResult<undefined>;
+  delete(opts: { path: string }): AsyncResult<undefined>;
+  move(opts: { path: string; newPath: string }): AsyncResult<undefined>;
+  makeDirectory(opts: { path: string }): AsyncResult<string[]>;
+  listDirectory(opts: { path: string }): AsyncResult<string[]>;
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -19,6 +19,6 @@ export interface NotebookFilesystem {
   put(opts: { path: string; value: string }): AsyncResult<undefined>;
   delete(opts: { path: string }): AsyncResult<undefined>;
   move(opts: { path: string; newPath: string }): AsyncResult<undefined>;
-  makeDirectory(opts: { path: string }): AsyncResult<string[]>;
+  makeDirectory(opts: { path: string }): AsyncResult<undefined>;
   listDirectory(opts: { path: string }): AsyncResult<string[]>;
 }

--- a/src/filesystem/filesystem.ts
+++ b/src/filesystem/filesystem.ts
@@ -1,0 +1,7 @@
+export interface NotebookFilesystem {
+  get(absolutePath: string): Promise<string>;
+  put(absolutePath: string, value: string): Promise<void>;
+  delete(absolutePath: string): Promise<void>;
+  listFiles(absolutePath: string): Promise<string[]>;
+  move(absolutePath: string, newAbsolutePath: string): Promise<void>;
+}

--- a/src/types/runtime/index.ts
+++ b/src/types/runtime/index.ts
@@ -238,17 +238,16 @@ export interface Runtime {
   exports: RuntimeExports;
 
   /**
-   * An optional filesystem that can be added by a plugin
-   */
-  fs?: NotebookFilesystem;
-
-  /**
    * Internal state, don't depend on this externally
    */
   internal: {
     listeners: {
       cellContentChanges: Map<string, (() => void)[]>;
     };
+    /**
+     * An optional filesystem that can be added by a plugin. Internal until we figure out the best way of dealing with this.
+     */
+    fs?: NotebookFilesystem;
   };
 
   /**

--- a/src/types/runtime/index.ts
+++ b/src/types/runtime/index.ts
@@ -49,6 +49,7 @@ import type {
   SetCellPropertyOptions,
 } from "../events";
 import type { getMarkdownItWithDefaultPlugins } from "../../components/helpers/markdown";
+import { NotebookFilesystem } from "../../filesystem/filesystem";
 
 export interface RuntimeControls {
   insertCell(opts: InsertCellOptions): string | false;
@@ -235,6 +236,11 @@ export interface Runtime {
   controls: RuntimeControls;
 
   exports: RuntimeExports;
+
+  /**
+   * An optional filesystem that can be added by a plugin
+   */
+  fs?: NotebookFilesystem;
 
   /**
    * Internal state, don't depend on this externally


### PR DESCRIPTION
This adds an optional filesystem to the notebook runtime. It's kept as simple and non-opinionated as possible. If you have other API suggestions, I'd be happy to incorporate them.

The plan is that
1. a plugin can add a filesystem (e.g. starboard-jupyter-filesystem)
2. starboard-python will then check if the notebook runtime has a filesystem
3. if yes, starboard-python will patch Pyodide/Emscripten

