### PR TITLE
Hotfix with broken paths for the built version of starboard-python

### DIFF
--- a/packages/starboard-python/package.json
+++ b/packages/starboard-python/package.json
@@ -9,7 +9,7 @@
     "build": "rimraf dist && rollup -c rollup.config.ts",
     "test": "starlit nbtest test --timeout=60",
     "test:nocoi": "starlit nbtest test --timeout=60 --cross_origin_isolated=false",
-    "postinstall": "node ../../node_modules/patch-package/dist/index.js"
+    "postinstall": "node $INIT_CWD/node_modules/patch-package/dist/index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/starboard-python/package.json
+++ b/packages/starboard-python/package.json
@@ -9,7 +9,7 @@
     "build": "rimraf dist && rollup -c rollup.config.ts",
     "test": "starlit nbtest test --timeout=60",
     "test:nocoi": "starlit nbtest test --timeout=60 --cross_origin_isolated=false",
-    "postinstall": "node node_modules/patch-package/dist/index.js"
+    "postinstall": "node ../../node_modules/patch-package/dist/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes the build (#83) ~but potentially introduces issues when running `npm install` in a development environment~

Update: Fixes the build *and* keeps development environment working