### PR TITLE
Move patch-package out of devDependencies to normal dependencies, since it's required at install time

### DIFF
--- a/packages/starboard-python/package.json
+++ b/packages/starboard-python/package.json
@@ -9,7 +9,7 @@
     "build": "rimraf dist && rollup -c rollup.config.ts",
     "test": "starlit nbtest test --timeout=60",
     "test:nocoi": "starlit nbtest test --timeout=60 --cross_origin_isolated=false",
-    "postinstall": "patch-package"
+    "postinstall": "patch-package || $INIT_CWD/node_modules/patch-package/dist/index.js"
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,8 @@
   "dependencies": {
     "@types/katex": "^0.11.1",
     "lit": "^2.0.2",
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0",
     "pyodide": "^0.18.1"
   },
   "devDependencies": {
@@ -39,7 +41,6 @@
     "@types/markdown-it": "^12.0.3",
     "clean-css": "^5.1.3",
     "nanoid": "^3.1.23",
-    "patch-package": "^6.4.7",
     "rimraf": "^3.0.2",
     "rollup": "^2.55.0",
     "rollup-plugin-dts": "^3.0.2",


### PR DESCRIPTION
Unfortunately, an `npm install` of `starboard-python` on a clean system is still broken, since `patch-package` is probably not present.

Since we want to run `patch-package` after a user installs `starboard-python`, it should be present, and therefore be included in the `dependencies`. `yarn` also gets the order of dependencies better if we include it in the `dependencies`, so `yarn install` works after this change.

For added convenience, I have also added the recommended `postinstall-postinstall` to the dependencies.