### PR TITLE
Update default CDN used to match 0.19.0

### DIFF
--- a/packages/starboard-python/src/worker/pyodide-worker.ts
+++ b/packages/starboard-python/src/worker/pyodide-worker.ts
@@ -60,7 +60,7 @@ class PyodideKernel implements WorkerKernel {
       this.proxiedDrawCanvas.apply({}, [pixels, width, height]);
     };
 
-    let artifactsURL = this.options.artifactsUrl || "https://cdn.jsdelivr.net/pyodide/v0.18.1/full/";
+    let artifactsURL = this.options.artifactsUrl || "https://cdn.jsdelivr.net/pyodide/v0.19.0/full/";
     if (!artifactsURL.endsWith("/")) artifactsURL += "/";
 
     if (!manager.proxy && !this.options.isMainThread) {


### PR DESCRIPTION
Sorry, missed bumping the fallback CDN version number in the previous PR, since I override this with my own Pyodide distribution.