### PR TITLE
WIP: Bump pyodide, starboard-python, starboard-notebook

### DIFF
--- a/packages/starboard-notebook/package.json
+++ b/packages/starboard-notebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starboard-notebook",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Starboard Notebook",
   "author": "Guido Zuidhof <me@guido.io>",
   "funding": {
@@ -137,7 +137,7 @@
     "prosemirror-state": "^1.3.4",
     "prosemirror-transform": "^1.2.12",
     "prosemirror-view": "^1.18.1",
-    "starboard-python": "^0.15.5",
+    "starboard-python": "^0.15.6",
     "starboard-rich-editor": "^0.15.2"
   },
   "gitHead": "beab3bbce7174c9ca32cabd80e00333683b3c97b"

--- a/packages/starboard-python/package.json
+++ b/packages/starboard-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starboard-python",
-  "version": "0.15.5",
+  "version": "0.15.6",
   "description": "Python cells for Starboard Notebook",
   "main": "dist/starboardPython.js",
   "module": "dist/starboardPython.js",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@types/katex": "^0.11.1",
     "lit": "^2.0.2",
-    "pyodide": "^0.19.0"
+    "pyodide": "^0.19.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.2",


### PR DESCRIPTION
I'll remove the WIP once I've seen this work, but could we upgrade to the latest Pyodide release? (although 0.20.0 is also around the corner)