### PR TITLE
Evaluate all script (grand)children of HTML output to render output of Bokeh and Plotly

### DIFF
--- a/packages/starboard-python/src/global.ts
+++ b/packages/starboard-python/src/global.ts
@@ -45,7 +45,7 @@ function drawCanvas(pixels: number[], width: number, height: number) {
   canvas.height = height;
   const ctx = canvas.getContext("2d");
   if (!ctx) {
-    console.warn("Failed to aquire canvas context");
+    console.warn("Failed to acquire canvas context");
     return;
   }
   ctx.putImageData(image, 0, 0);

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -72,8 +72,8 @@ export async function runStarboardPython(
             // Just putting HTML with script tags on the DOM will not get them evaluated
             // Using this hack we execute them anyway
             // TODO Don't re-evaluate all cells, but only do this for the current cell
-            document.querySelectorAll('div.cell-bottom * script[type|="text/javascript"]').forEach(
-              function(e) { eval(e.innerText); }
+            div.querySelectorAll('script[type|="text/javascript"]').forEach(
+              function(e) { eval(e.textContent); }
             )
             hadHTMLOutput = true;
           }

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -71,7 +71,6 @@ export async function runStarboardPython(
             htmlOutput.appendChild(div);
             // Just putting HTML with script tags on the DOM will not get them evaluated
             // Using this hack we execute them anyway
-            // TODO Don't re-evaluate all cells, but only do this for the current cell
             div.querySelectorAll('script[type|="text/javascript"]').forEach(
               function(e) { eval(e.textContent); }
             )

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -72,7 +72,11 @@ export async function runStarboardPython(
             // Just putting HTML with script tags on the DOM will not get them evaluated
             // Using this hack we execute them anyway
             div.querySelectorAll('script[type|="text/javascript"]').forEach(
-              function(e: string) { eval(e.textContent); }
+              function(e) {
+                if (e.textContent !== null) {
+                  eval(e.textContent);
+                }
+              }
             )
             hadHTMLOutput = true;
           }

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -53,6 +53,13 @@ export async function runStarboardPython(
 
       if (val instanceof HTMLElement) { // A plain HTML element
         htmlOutput.appendChild(val);
+        val.querySelectorAll('script[type|="text/javascript"]').forEach(
+              function(e) {
+                if (e.textContent !== null) {
+                  eval(e.textContent);
+                }
+              }
+            )
       } else if (typeof val === "object" && val.name === "PythonError" && val.__error_address) { // A python error
         error = val;
         outputElement.addEntry({

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -72,7 +72,7 @@ export async function runStarboardPython(
             // Just putting HTML with script tags on the DOM will not get them evaluated
             // Using this hack we execute them anyway
             div.querySelectorAll('script[type|="text/javascript"]').forEach(
-              function(e) { eval(e.textContent); }
+              function(e: string) { eval(e.textContent); }
             )
             hadHTMLOutput = true;
           }

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -53,6 +53,8 @@ export async function runStarboardPython(
 
       if (val instanceof HTMLElement) { // A plain HTML element
         htmlOutput.appendChild(val);
+        // Just putting HTML with script tags on the DOM will not get them evaluated
+        // Using this hack we execute them anyway
         val.querySelectorAll('script[type|="text/javascript"]').forEach(
               function(e) {
                 if (e.textContent !== null) {
@@ -76,8 +78,7 @@ export async function runStarboardPython(
             div.className = "rendered_html cell-output-html";
             div.appendChild(new DOMParser().parseFromString(result, "text/html").body.firstChild as any);
             htmlOutput.appendChild(div);
-            // Just putting HTML with script tags on the DOM will not get them evaluated
-            // Using this hack we execute them anyway
+            // Evaluate all script tags manually, see previous comment
             div.querySelectorAll('script[type|="text/javascript"]').forEach(
               function(e) {
                 if (e.textContent !== null) {

--- a/packages/starboard-python/src/run.ts
+++ b/packages/starboard-python/src/run.ts
@@ -69,6 +69,12 @@ export async function runStarboardPython(
             div.className = "rendered_html cell-output-html";
             div.appendChild(new DOMParser().parseFromString(result, "text/html").body.firstChild as any);
             htmlOutput.appendChild(div);
+            // Just putting HTML with script tags on the DOM will not get them evaluated
+            // Using this hack we execute them anyway
+            // TODO Don't re-evaluate all cells, but only do this for the current cell
+            document.querySelectorAll('div.cell-bottom * script[type|="text/javascript"]').forEach(
+              function(e) { eval(e.innerText); }
+            )
             hadHTMLOutput = true;
           }
         } else if (val._repr_latex_ !== undefined) { // It has a LateX representation (e.g. Sympy output)


### PR DESCRIPTION
(As discussed on the Discord server) to render plotly in Starboard Notebook I was coming up with this kind of hack: manually evaluating Javascript that was added to the DOM:

```javascript
document.querySelectorAll('div.cell-bottom * script[type|="text/javascript"]').forEach(function(e) { eval(e.innerText); })
```

This PR is intended to start the discussion on if and how we might want to address this in Starboard Notebook itself. Right now libraries, like Bokeh and Plotly will not work out of the box, which is unfortunate.

We should also consider security implications of a fix similar to this one. Of course it helps if CORS and friends are configured properly, but there might be more risks besides stealing (session) data from a user by having them execute malicious code.

### Plotly example
```python
import pandas  # to populate the entry in sys.modules and keep plotly happy
import micropip
await micropip.install('plotly')
import plotly.express as px
from js import document

x = [1, 2, 3]
y = [1, 2, 3]
fig = px.scatter(x=x, y=y)
html = fig.to_html(
    include_plotlyjs=True,
    full_html=False,
    default_height='350px',
)

div = document.createElement('div')
div.innerHTML = html
div
```

```javascript
document.querySelectorAll('div.cell-bottom * script[type|="text/javascript"]').forEach(function(e) { eval(e.innerText); })
```

### Bokeh example
```python
from bokeh.plotting import figure, show, save
from bokeh.io import output_file
from js import document

p = figure()
p.line([1, 2, 3], [1, 2, 3])
output_file('/tmp/output.html', mode='inline')
save(p)

# TODO bokeh probably has a better way to get this HTML out
with open('/tmp/output.html', 'r') as f:
    contents = f.read()
div = document.createElement('div')
div.innerHTML = contents
div
```

```javascript
document.querySelectorAll('div.cell-bottom * script[type|="text/javascript"]').forEach(function(e) { eval(e.innerText); })
```